### PR TITLE
Update workflow to diff two profile reports

### DIFF
--- a/.github/workflows/scripts/diff-builds
+++ b/.github/workflows/scripts/diff-builds
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+diff -ur --color=always $@
+exit 0

--- a/.github/workflows/scripts/memprof.rb
+++ b/.github/workflows/scripts/memprof.rb
@@ -14,7 +14,17 @@ reporter = MemoryProfiler.report(allow_files: ['lib/kramdown']) do
 end
 
 if ENV['KD_PATH']
-  reporter.pretty_print(to_file: "#{ARGV[0]}/memprof.txt", scale_bytes: true, normalize_paths: true)
+  report_file = "#{ARGV[0]}/memprof.txt"
+  reporter.pretty_print(to_file: report_file, scale_bytes: true, normalize_paths: true)
+  if ARGV[0] == 'master'
+  puts ''
+  puts 'Normalizing paths..'
+    contents = File.binread(report_file)
+    contents = contents('  master/', '  calmdown/')
+    File.binwrite(report_file, contents)
+  end
+  puts ''
+  puts "Detailed Report saved into: #{report_file.cyan}"
 else
   reporter.pretty_print(scale_bytes: true, normalize_paths: true)
 end

--- a/.github/workflows/scripts/memprof.rb
+++ b/.github/workflows/scripts/memprof.rb
@@ -3,12 +3,18 @@
 require 'jekyll'
 require 'memory_profiler'
 
-MemoryProfiler.report(allow_files: ['lib/kramdown']) do
+reporter = MemoryProfiler.report(allow_files: ['lib/kramdown']) do
   Jekyll::PluginManager.require_from_bundler
   Jekyll::Commands::Build.process({
-    "source"             => File.expand_path(ARGV[0]),
-    "destination"        => File.expand_path("#{ARGV[0]}/_site"),
+    "source"             => File.expand_path("sandbox"),
+    "destination"        => File.expand_path("sandbox/_site"),
     "disable_disk_cache" => true,
   })
   puts ''
-end.pretty_print(scale_bytes: true, normalize_paths: true)
+end
+
+if ENV['KD_PATH']
+  reporter.pretty_print(to_file: "#{ARGV[0]}/memprof.txt", scale_bytes: true, normalize_paths: true)
+else
+  reporter.pretty_print(scale_bytes: true, normalize_paths: true)
+end

--- a/.github/workflows/scripts/memprof.rb
+++ b/.github/workflows/scripts/memprof.rb
@@ -17,10 +17,9 @@ if ENV['KD_PATH']
   report_file = "#{ARGV[0]}/memprof.txt"
   reporter.pretty_print(to_file: report_file, scale_bytes: true, normalize_paths: true)
   if ARGV[0] == 'master'
-  puts ''
-  puts 'Normalizing paths..'
+    puts 'Normalizing paths..'
     contents = File.binread(report_file)
-    contents = contents('  master/', '  calmdown/')
+    contents = contents.gsub('  master/', '  calmdown/')
     File.binwrite(report_file, contents)
   end
   puts ''

--- a/.github/workflows/scripts/memprof.rb
+++ b/.github/workflows/scripts/memprof.rb
@@ -21,8 +21,10 @@ if ENV['KD_PATH']
     contents = File.binread(report_file)
     contents = contents.gsub('  master/', '  calmdown/')
     File.binwrite(report_file, contents)
+  else
+    reporter.pretty_print(scale_bytes: true, normalize_paths: true)
+    puts ''
   end
-  puts ''
   puts "Detailed Report saved into: #{report_file.cyan}"
 else
   reporter.pretty_print(scale_bytes: true, normalize_paths: true)

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -5,45 +5,8 @@ on:
     branches:
       - master
 jobs:
-  build_n_profile:
-    name: "Third-Party Repo Profile (Ruby ${{ matrix.ruby_version }})"
-    runs-on: "ubuntu-latest"
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version:
-        - 2.5
-        - 2.7
-    env:
-      BUNDLE_GEMFILE: "sandbox/Gemfile"
-      BUNDLE_PATH: "vendor/bundle"
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 3
-        path: calmdown
-    - name: Checkout Third-Party Jekyll Project Repository
-      uses: actions/checkout@v2
-      with:
-        repository: ashmaroli/tomjoht.github.io
-        ref: calmdown
-        path: sandbox
-    - name: "Set up Ruby ${{ matrix.ruby_version }}"
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby_version }}
-        bundler-cache: true
-    - name: Run Jekyll Build 3 times
-      run: |
-        bundle exec jekyll build -s sandbox -d sandbox/_site --trace
-        bundle exec jekyll build -s sandbox -d sandbox/_site --trace
-        bundle exec jekyll build -s sandbox -d sandbox/_site --trace
-
   diff_profiles:
-    name: "Third-Party Repo Memory Profile (Ruby ${{ matrix.ruby_version }})"
+    name: "Third-Party Repo Profile (Ruby ${{ matrix.ruby_version }})"
     runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
@@ -80,6 +43,14 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby_version }}
         bundler-cache: true
+    - name: Run Jekyll Build 3 times with master
+      env:
+        KD_PATH: "../master"
+      run: |
+        bundle install --quiet
+        bundle exec jekyll build -s sandbox -d sandbox/_site --trace >> master_build.txt
+        bundle exec jekyll build -s sandbox -d sandbox/_site --trace >> master_build.txt
+        bundle exec jekyll build -s sandbox -d sandbox/_site --trace >> master_build.txt
     - name: Memory Analysis of Jekyll Build with master
       env:
         KD_PATH: "../master"
@@ -87,6 +58,14 @@ jobs:
         bundle install --quiet
         echo
         bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb master
+    - name: Run Jekyll Build 3 times with ref
+      env:
+        KD_PATH: "../calmdown"
+      run: |
+        bundle install --quiet
+        bundle exec jekyll build -s sandbox -d sandbox/_site --trace >> ref_build.txt
+        bundle exec jekyll build -s sandbox -d sandbox/_site --trace >> ref_build.txt
+        bundle exec jekyll build -s sandbox -d sandbox/_site --trace >> ref_build.txt
     - name: Memory Analysis of Jekyll Build with ref
       env:
         KD_PATH: "../calmdown"
@@ -95,4 +74,7 @@ jobs:
         echo
         bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb sandbox
     - name: Diff two profile reports
-      run: bash calmdown/.github/workflows/scripts/diff-builds master/memprof.txt sandbox/memprof.txt
+      run: |
+        bash calmdown/.github/workflows/scripts/diff-builds master_build.txt ref_build.txt
+        echo
+        bash calmdown/.github/workflows/scripts/diff-builds master/memprof.txt sandbox/memprof.txt

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -84,14 +84,14 @@ jobs:
         bundler-cache: true
     - name: Memory Analysis of Jekyll Build with master
       env:
-        KD_PTH: "../master"
+        KD_PATH: "../master"
       run: |
         bundle install
         echo
         bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb master
     - name: Memory Analysis of Jekyll Build with ref
       env:
-        KD_PTH: "../calmdown"
+        KD_PATH: "../calmdown"
       run: |
         bundle install
         echo

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -41,11 +41,9 @@ jobs:
         bundle exec jekyll build -s sandbox -d sandbox/_site --trace
         bundle exec jekyll build -s sandbox -d sandbox/_site --trace
         bundle exec jekyll build -s sandbox -d sandbox/_site --trace
-    - name: Memory Analysis of Jekyll Build
-      run: bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb
 
   diff_profiles:
-    name: "Third-Party Repo Profile Diffs (Ruby ${{ matrix.ruby_version }})"
+    name: "Third-Party Repo Memory Profile (Ruby ${{ matrix.ruby_version }})"
     runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
@@ -86,14 +84,14 @@ jobs:
       env:
         KD_PATH: "../master"
       run: |
-        bundle install
+        bundle install --quiet
         echo
         bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb master
     - name: Memory Analysis of Jekyll Build with ref
       env:
         KD_PATH: "../calmdown"
       run: |
-        bundle install
+        bundle install --quiet
         echo
         bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb sandbox
     - name: Diff two profile reports

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -1,9 +1,6 @@
 name: Third-Party Repository Profiling
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -45,4 +42,59 @@ jobs:
         bundle exec jekyll build -s sandbox -d sandbox/_site --trace
         bundle exec jekyll build -s sandbox -d sandbox/_site --trace
     - name: Memory Analysis of Jekyll Build
-      run: bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb sandbox
+      run: bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb
+
+  diff_profiles:
+    name: "Third-Party Repo Profile Diffs (Ruby ${{ matrix.ruby_version }})"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+        - 2.5
+        - 2.7
+    env:
+      BUNDLE_GEMFILE: "sandbox/Gemfile"
+      BUNDLE_PATH: "vendor/bundle"
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+    steps:
+    - name: Checkout Repository @ ref
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 3
+        path: calmdown
+    - name: Checkout Repository @ master
+      uses: actions/checkout@v2
+      with:
+        repository: ashmaroli/calmdown
+        ref: master
+        fetch-depth: 3
+        path: master
+    - name: Checkout Third-Party Jekyll Project Repository
+      uses: actions/checkout@v2
+      with:
+        repository: ashmaroli/tomjoht.github.io
+        ref: calmdown
+        path: sandbox
+    - name: "Set up Ruby ${{ matrix.ruby_version }}"
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+        bundler-cache: true
+    - name: Memory Analysis of Jekyll Build with master
+      env:
+        KD_PTH: "../master"
+      run: |
+        bundle install
+        echo
+        bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb master
+    - name: Memory Analysis of Jekyll Build with ref
+      env:
+        KD_PTH: "../calmdown"
+      run: |
+        bundle install
+        echo
+        bundle exec ruby calmdown/.github/workflows/scripts/memprof.rb sandbox
+    - name: Diff two profile reports
+      run: bash calmdown/.github/workflows/scripts/diff-builds master/memprof.txt sandbox/memprof.txt


### PR DESCRIPTION
- Stop triggering workflow for `push` events.
- Diff two reports in addition to printing full report for PR branch.